### PR TITLE
Fixed broken tests in the package that were calling too many futures.

### DIFF
--- a/src/classes/ActionPlanDetailController.cls
+++ b/src/classes/ActionPlanDetailController.cls
@@ -270,51 +270,35 @@ public with sharing class ActionPlanDetailController{
         
         Test.StopTest();
     }
-    
-    public static testMethod void checkGetRelatedObjectName(){
-        
+
+    private static void checkGetRelatedObjectName(String planType) {
         ActionPlansTestUtilities testUtil = new ActionPlansTestUtilities();
         
-        ActionPlan__c actionPlan = testUtil.createNewActionPlan( 'accounts', 0 );
+        ActionPlan__c actionPlan = testUtil.createNewActionPlan( planType, 0 );
+
         System.currentPageReference().getParameters().put( 'id', actionPlan.Id );
         ActionPlanDetailController APDC = new ActionPlanDetailController( new ApexPages.StandardController( new ActionPlan__c() ) ); 
         String name = APDC.getRelatedObjectName();
         System.assert(name != null);
-        
-        actionPlan = testUtil.createNewActionPlan( 'campaigns', 0 );
-        System.currentPageReference().getParameters().put( 'id', actionPlan.Id );
-        APDC = new ActionPlanDetailController( new ApexPages.StandardController( new ActionPlan__c() ) ); 
-        name = APDC.getRelatedObjectName();
-        System.assert(name != null);
-        
-        actionPlan = testUtil.createNewActionPlan( 'cases', 0 );
-        System.currentPageReference().getParameters().put( 'id', actionPlan.Id );
-        APDC = new ActionPlanDetailController( new ApexPages.StandardController( new ActionPlan__c() ) ); 
-        name = APDC.getRelatedObjectName();
-        System.assert(name != null);
-        
-        actionPlan = testUtil.createNewActionPlan( 'contacts', 0 );
-        System.currentPageReference().getParameters().put( 'id', actionPlan.Id );
-        APDC = new ActionPlanDetailController( new ApexPages.StandardController( new ActionPlan__c() ) ); 
-        name = APDC.getRelatedObjectName();
-        System.assert(name != null);
-        
-        actionPlan = testUtil.createNewActionPlan( 'contracts', 0 );
-        System.currentPageReference().getParameters().put( 'id', actionPlan.Id );
-        APDC = new ActionPlanDetailController( new ApexPages.StandardController( new ActionPlan__c() ) ); 
-        name = APDC.getRelatedObjectName();
-        System.assert(name != null);
-        
-        actionPlan = testUtil.createNewActionPlan( 'leads', 0 );
-        System.currentPageReference().getParameters().put( 'id', actionPlan.Id );
-        APDC = new ActionPlanDetailController( new ApexPages.StandardController( new ActionPlan__c() ) ); 
-        name = APDC.getRelatedObjectName();
-        System.assert(name != null);
-        
-        actionPlan = testUtil.createNewActionPlan( 'opportunitys', 0 );
-        System.currentPageReference().getParameters().put( 'id', actionPlan.Id );
-        APDC = new ActionPlanDetailController( new ApexPages.StandardController( new ActionPlan__c() ) ); 
-        name = APDC.getRelatedObjectName();
-        System.assert(name != null);
     }
+
+    public static testMethod void checkGetRelatedObjectNameCampaigns(){
+        checkGetRelatedObjectName('campaigns');
+    }
+    public static testMethod void checkGetRelatedObjectNameCases(){
+        checkGetRelatedObjectName('cases');
+    }
+    public static testMethod void checkGetRelatedObjectNameContacts(){
+        checkGetRelatedObjectName('contacts');
+    }
+    public static testMethod void checkGetRelatedObjectNameContracts(){
+        checkGetRelatedObjectName('contracts');
+    }
+    public static testMethod void checkGetRelatedObjectNameLeads(){
+        checkGetRelatedObjectName('leads');
+    }
+    public static testMethod void checkGetRelatedObjectNameOpportunitys(){
+        checkGetRelatedObjectName('opportunitys');
+    }
+
 }

--- a/src/classes/ActionPlansBatchBuilderTest.cls
+++ b/src/classes/ActionPlansBatchBuilderTest.cls
@@ -180,12 +180,13 @@ public with sharing class ActionPlansBatchBuilderTest {
 		
 			ActionPlan__c ap = ge.createNewActionPlan( 'opportunitys' ,2);
 			List<APTaskTemplate__c> apTasks = new List<APTaskTemplate__c>();
-		
+			List<User> users = ge.createTestUser(2);
+
 			APTaskTemplate__c at = new APTaskTemplate__c();
 	   		at.Action_Plan__c 	 = ap.Id;
 	   		at.Dependent__c		 = 'None';
 	   		at.DaysFromStart__c  = 2.0;
-	   		at.User__c			 = ge.createTestUser().Id;
+	      at.User__c       = users[0].Id;
 	   		at.SendEmail__c		 = false;
 	   		at.Subject__c		 = 'Test ';
 	   		at.Type__c			 = 'Email';
@@ -200,7 +201,7 @@ public with sharing class ActionPlansBatchBuilderTest {
 	   		at.Action_Plan__c 	 = ap.Id;
 	   		at.Dependent__c		 = 'None';
 	   		at.DaysFromStart__c  = 2.0;
-	   		at.User__c			 = ge.createTestUser().Id;
+	      at.User__c       = users[1].Id;
 	   		at.SendEmail__c		 = true;
 	   		at.Subject__c		 = 'Test ';
 	   		at.Type__c			 = 'Email';
@@ -260,12 +261,13 @@ public with sharing class ActionPlansBatchBuilderTest {
 		
 			ActionPlan__c ap = ge.createNewActionPlan( 'opportunitys' ,2);
 			List<APTaskTemplate__c> apTasks = new List<APTaskTemplate__c>();
+			List<User> users = ge.createTestUser(2);
 		
 			APTaskTemplate__c at = new APTaskTemplate__c();
 	   		at.Action_Plan__c 	 = ap.Id;
 	   		at.Dependent__c		 = 'None';
 	   		at.DaysFromStart__c  = 2.0;
-	   		at.User__c			 = ge.createTestUser().Id;
+	      at.User__c       = users[0].Id;
 	   		at.SendEmail__c		 = false;
 	   		at.Subject__c		 = 'Test ';
 	   		at.Type__c			 = 'Email';
@@ -280,7 +282,7 @@ public with sharing class ActionPlansBatchBuilderTest {
 	   		at.Action_Plan__c 	 = ap.Id;
 	   		at.Dependent__c		 = 'None';
 	   		at.DaysFromStart__c  = 2.0;
-	   		at.User__c			 = ge.createTestUser().Id;
+	      at.User__c       = users[1].Id;
 	   		at.SendEmail__c		 = true;
 	   		at.Subject__c		 = 'Test ';
 	   		at.Type__c			 = 'Email';

--- a/src/classes/ActionPlansBatchTaskBuilderTest.cls
+++ b/src/classes/ActionPlansBatchTaskBuilderTest.cls
@@ -30,6 +30,7 @@ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISE
 OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
+@isTest
 public with sharing class ActionPlansBatchTaskBuilderTest {
 	
 	

--- a/src/classes/ActionPlansTaskTriggerUtilitiesTest.cls
+++ b/src/classes/ActionPlansTaskTriggerUtilitiesTest.cls
@@ -49,13 +49,14 @@ private class ActionPlansTaskTriggerUtilitiesTest {
     	List<Id> apTTaskIds 		= new List<Id>();
     	List<Task> apTask 			= new List<Task>();
     	List<APTaskTemplate__c> aptt = new List<APTaskTemplate__c>();
+      List<User> users       = ge.createTestUser(4);
     	
 		Test.startTest();
 		   	for( Integer i = 0; i < 4; i++ ){
 		   		APTaskTemplate__c at = new APTaskTemplate__c();
 		   		at.Action_Plan__c 	 = ap.Id;
 		   		at.DaysFromStart__c  = 2.0;
-		   		at.User__c			 = ge.createTestUser().Id;
+	        at.User__c			 = users[i].Id;
 		   		if (i == 0){
 		   			at.SendEmail__c		 = true;
 		   		}else{
@@ -104,13 +105,14 @@ private class ActionPlansTaskTriggerUtilitiesTest {
     	List<Id> apTTaskIds 		= new List<Id>();
     	List<Task> apTask 			= new List<Task>();
     	List<APTaskTemplate__c> aptt = new List<APTaskTemplate__c>();
+      List<User> users			= ge.createTestUser(4);
 		
 		Test.startTest();
 		   	for( Integer i = 0; i < 4; i++ ){
 		   		APTaskTemplate__c at = new APTaskTemplate__c();
 		   		at.Action_Plan__c 	 = ap.Id;
 		   		at.DaysFromStart__c  = 2.0;
-		   		at.User__c			 = ge.createTestUser().Id;
+		      at.User__c			 = users[i].Id;
 		   		at.SendEmail__c		 = false;
 		   		at.Subject__c		 = 'Test '+ i;
 		   		at.Type__c			 = 'Email';
@@ -152,13 +154,14 @@ private class ActionPlansTaskTriggerUtilitiesTest {
     	List<Id> apTTaskIds 		= new List<Id>();
     	List<Task> apTask 			= new List<Task>();
     	List<APTaskTemplate__c> aptt = new List<APTaskTemplate__c>();
-		
+     List<User> users			= ge.createTestUser(4);
+
 		Test.startTest();
 		   	for( Integer i = 0; i < 4; i++ ){
 		   		APTaskTemplate__c at = new APTaskTemplate__c();
 		   		at.Action_Plan__c 	 = ap.Id;
 		   		at.DaysFromStart__c  = 2.0;
-		   		at.User__c			 = ge.createTestUser().Id;
+		      at.User__c			 = users[i].Id;
 		   		at.SendEmail__c		 = false;
 		   		at.Subject__c		 = 'Test '+ i;
 		   		at.Type__c			 = 'Email';
@@ -301,13 +304,14 @@ private class ActionPlansTaskTriggerUtilitiesTest {
 		List<Id> apTTaskIds 		= new List<Id>();
 		List<Task> apTask 			= new List<Task>();
 		List<APTaskTemplate__c> aptt = new List<APTaskTemplate__c>();
+    List<User> users			= ge.createTestUser(4);
 		
 		Test.startTest();
 		   	for( Integer i = 0; i < 4; i++ ){
 		   		APTaskTemplate__c at = new APTaskTemplate__c();
 		   		at.Action_Plan__c 	 = ap.Id;
 		   		at.DaysFromStart__c  = 2.0;
-		   		at.User__c			 = ge.createTestUser().Id;
+		      at.User__c			 = users[i].Id;
 		   		if (i == 0){
 		   			at.SendEmail__c		 = true;
 		   		}else{
@@ -353,12 +357,13 @@ private class ActionPlansTaskTriggerUtilitiesTest {
 		test.startTest();
 		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
 		ActionPlan__c ap 			= ge.createNewActionPlan( 'accounts', 0 );
+    List<User> users			= ge.createTestUser(2);
 				
 		//Task Template 1
 		APTaskTemplate__c at = new APTaskTemplate__c();
 		at.Action_Plan__c 	 = ap.Id;
 		at.DaysFromStart__c  = 2.0;
-		at.User__c				= ge.createTestUser().Id;
+		at.User__c				= users[0].Id;
 		at.SendEmail__c			= true;
 		at.Subject__c			= 'Test ';
 		at.Type__c				= 'Email';
@@ -370,7 +375,7 @@ private class ActionPlansTaskTriggerUtilitiesTest {
 		APTaskTemplate__c at2 = new APTaskTemplate__c();
 		at2.Action_Plan__c		= ap.Id;
 		at2.DaysFromStart__c	= 2.0;
-		at2.User__c				= ge.createTestUser().Id;
+		at2.User__c				= users[1].Id;
 		at2.SendEmail__c		= true;
 		at2.Subject__c			= 'Test2' ;
 		at2.Type__c				= 'Email';

--- a/src/classes/ActionPlansTestUtilities.cls
+++ b/src/classes/ActionPlansTestUtilities.cls
@@ -83,13 +83,29 @@ public with sharing class ActionPlansTestUtilities{
     * sure that you are able to see data across posts regardless
     * of follow status.
   	*/
-  	public User createTestUser() {
+    public User createTestUser() {
+        return createTestUser(1)[0];
+    }
+
+   public List<User> createTestUser(Integer numberOfUsers) {
+        Profile prof = null;
     	for( Profile p : [ Select Id, PermissionsModifyAllData, Name from Profile limit 100 ] ){
     		if( p.PermissionsModifyAllData ){
-    			return this.createTestUser( p );
+         prof = p;
     		}
     	}
-    	return new User();
+
+      List<User> users = new List<User>();
+
+      for(Integer i = 0; i < numberOfUsers; i++) {
+          if(prof != null) {
+              users.add(this.createTestUser( prof ));
+          } else {
+              users.add(new User());
+          }
+      }
+      insert users;
+      return users;
   	}
   
   	/**
@@ -110,9 +126,7 @@ public with sharing class ActionPlansTestUtilities{
     	testUser.LocaleSidKey 		= 'en_US';
     	testUser.TimeZoneSidKey 	= 'America/Chicago';
     	testUser.EmailEncodingKey 	= 'UTF-8';
-    	
-    	insert testUser;
-    	
+
     	return testUser;
   	}
  	
@@ -306,15 +320,16 @@ public with sharing class ActionPlansTestUtilities{
  		catch( Exception ex ){
  			System.assert( false ,' Inserting Action Plan failed,' + ex );
  		}
- 		
+
  		APTaskTemplate__c auxTask = new APTaskTemplate__c();
  		User user = this.createTestUser();
 
+        List<APTaskTemplate__c> objs = new List<APTaskTemplate__c>();
  		//Creates default tasks for Action Plan
  		for( Integer i = 0; i < numTasks; i++ ){
- 			auxTask = this.createNewActionPlanTask( newActionPlan, 1, user, 'Email', 'High' );
+				objs.add(this.createNewActionPlanTask( newActionPlan, 1, user, 'Email', 'High' ));
  		}
- 		
+			insert objs;
  		
  		
  		return newActionPlan;
@@ -334,13 +349,6 @@ public with sharing class ActionPlansTestUtilities{
  		newAPTask.Type__c 			= category;
  		newAPTask.Priority__c 		= priority;
  		newAPTask.Minutes_Reminder__c = '510';
- 		
- 		try{
- 			insert newAPTask;
- 		}
- 		catch( Exception ex ){
- 			System.assert( false ,' Inserting Action Plan task failed,' + ex );
- 		}
  				
  		return newAPTask;
  	}
@@ -406,13 +414,15 @@ public with sharing class ActionPlansTestUtilities{
  	public List<String> batchIds( String ref ){
  		
 	 		ActionPlan__c ap = this.createNewActionPlan( ref ,0);
+            List<User> users = this.createTestUser(2);
+            List<APTaskTemplate__c> templates = new List<APTaskTemplate__c>();
 			List<String> apTasksIds = new List<String>();
 		
 			APTaskTemplate__c at = new APTaskTemplate__c();
 	   		at.Action_Plan__c 	 = ap.Id;
 	   		at.Dependent__c		 = 'None';
 	   		at.DaysFromStart__c  = 2.0;
-	   		at.User__c			 = this.createTestUser().Id;
+	      at.User__c			 = users[0].Id;
 	   		at.SendEmail__c		 = false;
 	   		at.Subject__c		 = 'Test ';
 	   		at.Type__c			 = 'Email';
@@ -420,23 +430,25 @@ public with sharing class ActionPlansTestUtilities{
 	   		at.Comments__c		 = 'Test';
 	   		at.Reminder__c		 = true;
 	   		at.Minutes_Reminder__c = '510';
-	   		insert at;
-	   		apTasksIds.add(at.Id);
+	      templates.add(at);
 	   		
-	   		at = new APTaskTemplate__c();
-	   		at.Action_Plan__c 	 = ap.Id;
-	   		at.Dependent__c		 = 'None';
-	   		at.DaysFromStart__c  = 2.0;
-	   		at.User__c			 = this.createTestUser().Id;
-	   		at.SendEmail__c		 = true;
-	   		at.Subject__c		 = 'Test ';
-	   		at.Type__c			 = 'Email';
-	   		at.Priority__c		 = 'Low';
-	   		at.Comments__c		 = 'Test';
-	   		at.Reminder__c		 = true;
-	   		at.Minutes_Reminder__c = '510';
-	   		insert at;
-	   		apTasksIds.add(at.Id);
+	      APTaskTemplate__c at2 = new APTaskTemplate__c();
+	      at2.Action_Plan__c 	 = ap.Id;
+	      at2.Dependent__c		 = 'None';
+	      at2.DaysFromStart__c = 2.0;
+	      at2.User__c			 = users[1].Id;
+	      at2.SendEmail__c		 = true;
+	      at2.Subject__c		 = 'Test ';
+	      at2.Type__c			 = 'Email';
+	      at2.Priority__c		 = 'Low';
+	      at2.Comments__c		 = 'Test';
+	      at2.Reminder__c		 = true;
+	      at2.Minutes_Reminder__c = '510';
+	      templates.add(at2);
+       insert(templates);
+
+       apTasksIds.add(templates[0].Id);
+       apTasksIds.add(templates[1].Id);
 	   		
 	   		return apTasksIds;
  	}

--- a/src/classes/ActionPlansUtilitiesTest.cls
+++ b/src/classes/ActionPlansUtilitiesTest.cls
@@ -145,50 +145,50 @@ public with sharing class ActionPlansUtilitiesTest {
 	}	
 	
 	
-	private static testMethod void APUtestSaveMasiveMethodPart1() {
+	private static testMethod void APUtestSaveMasiveMethodCase() {
 		
 		Map<String,String> objectDetails = new Map<String,String>();
 		objectDetails.put('cases','Case');
+		APUtestSaveMasiveMethod(objectDetails);
+	}
+
+	private static testMethod void APUtestSaveMasiveMethodContact() {
+		Map<String,String> objectDetails = new Map<String,String>();
 		objectDetails.put('contacts','Contact');
-		objectDetails.put('leads','Lead');//
-		test.startTest();
+		APUtestSaveMasiveMethod(objectDetails);
+	}
+
+	private static testMethod void APUtestSaveMasiveMethodLead() {
+		Map<String,String> objectDetails = new Map<String,String>();
 		
-		ActionPlansTestUtilities ge =  new ActionPlansTestUtilities();
-		ActionPlan__c ap = null;		
-		for(String k : objectDetails.keySet()){
-			ap = ge.createNewActionPlan( k, 0 );
-			ap.SkipWeekends__c 	= true;
-			ap.SkipDay__c = 'Monday';
-			update ap;
-			
-			ApexPages.currentPage().getParameters().put( 'refType', objectDetails.get(k) );
-			
-			
-			ActionPlansUtilities apu = new ActionPlansUtilities( ap );
-	   		apu.apTasks = new List<APTaskTemplate__c>();
-	   		apu.apTasks.add( ActionPlansUtilitiesTest.apptask( ap ) );
-	
-			apu.save();
-			
-			ActionPlanTemplate__c apt = ge.createNewActionPlanTemplate( 5 );
-			ApexPages.currentPage().getParameters().put( 'templateId', apt.Id );
-			apu = new ActionPlansUtilities( new ActionPlan__c() );
-			apu.apTasks = apu.getTasks();
-			
-			System.assert( !apu.apTasks.isEmpty() );
-		}		
-				
-		test.stopTest();		
+		objectDetails.put('leads','Lead');
+		APUtestSaveMasiveMethod(objectDetails);
 	}
 	
-	private static testMethod void APUtestSaveMasiveMethodPart2() {
+	private static testMethod void APUtestSaveMasiveMethodContract() {
 		
 		Map<String,String> objectDetails = new Map<String,String>();
 		objectDetails.put('contracts','Contract');
+		APUtestSaveMasiveMethod(objectDetails);
+	}
+
+	private static testMethod void APUtestSaveMasiveMethodCampaign() {
+		Map<String,String> objectDetails = new Map<String,String>();
+
 		objectDetails.put('campaigns','Campaign');
+		APUtestSaveMasiveMethod(objectDetails);
+	}
+
+	private static testMethod void APUtestSaveMasiveMethodOpportunity() {
+		Map<String,String> objectDetails = new Map<String,String>();
+
 		objectDetails.put('opportunitys','Opportunity');
-		test.startTest();
+		APUtestSaveMasiveMethod(objectDetails);
+	}
+
+	private static void APUtestSaveMasiveMethod(Map<String,String> objectDetails) {
 		
+		test.startTest();
 		ActionPlansTestUtilities ge =  new ActionPlansTestUtilities();
 		ActionPlan__c ap = null;		
 		for(String k : objectDetails.keySet()){
@@ -217,76 +217,150 @@ public with sharing class ActionPlansUtilitiesTest {
 		test.stopTest();		
 	}
 	
-	
-	private static testMethod void APUtestCancel() {
+	private static testMethod void APUtestCancelNothing() {
 		Test.startTest();
 		ActionPlansUtilities apu = new ActionPlansUtilities();
 		PageReference page = apu.cancel();
 		System.assert( page!= null );
-		
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestCancelAccount() {
+		Test.startTest();
+		ActionPlansUtilities apu = new ActionPlansUtilities();
 		ActionPlansTestUtilities ge =  new ActionPlansTestUtilities();
 		
 		ActionPlan__c ap = ge.createNewActionPlan( 'accounts', 0 );
 		ApexPages.currentPage().getParameters().put( 'refType', 'Account' );
 		ApexPages.currentPage().getParameters().put( 'refId' ,  ap.Account__c + ',' + ge.createNewAccount().id);
-		page = apu.cancel();
+		PageReference page = apu.cancel();
 		System.assert( page!= null );
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestCancelContact() {
+		Test.startTest();
+		ActionPlansUtilities apu = new ActionPlansUtilities();
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
 		
-		ge.createNewActionPlan( 'contacts', 0 );
+		ActionPlan__c ap = ge.createNewActionPlan( 'contacts', 0 );
 		ApexPages.currentPage().getParameters().put( 'refType', 'Contact' );
 		ApexPages.currentPage().getParameters().put( 'refId' ,  ap.Contact__c + ',' + ge.createNewContact().id);
-		page = apu.cancel();
+		PageReference page = apu.cancel();
 		System.assert( page!= null );
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestCancelLead() {
+		Test.startTest();
+		ActionPlansUtilities apu = new ActionPlansUtilities();
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
 		
-		ge.createNewActionPlan( 'leads', 0 );
+		ActionPlan__c ap = ge.createNewActionPlan( 'leads', 0 );
 		ApexPages.currentPage().getParameters().put( 'refType', 'Lead' );
 		ApexPages.currentPage().getParameters().put( 'refId' ,  ap.Lead__c + ',' + ge.createNewLead().id);
-		page = apu.cancel();
+		PageReference page = apu.cancel();
 		System.assert( page!= null );
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestCancelOpportunity() {
+		Test.startTest();
+		ActionPlansUtilities apu = new ActionPlansUtilities();
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
 		
-		ge.createNewActionPlan( 'opportunitys', 0 );
+		ActionPlan__c ap = ge.createNewActionPlan( 'opportunitys', 0 );
 		ApexPages.currentPage().getParameters().put( 'refType', 'Opportunity' );
 		ApexPages.currentPage().getParameters().put( 'refId' ,  ap.Opportunity__c + ',' + ge.createNewOpportunity().id);
-		page = apu.cancel();
+		PageReference page = apu.cancel();
 		System.assert( page!= null );
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestCancelCase() {
+		Test.startTest();
+		ActionPlansUtilities apu = new ActionPlansUtilities();
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
 		
-		ge.createNewActionPlan( 'accounts', 0 );
-		ApexPages.currentPage().getParameters().put( 'refType', 'Account' );
-		ApexPages.currentPage().getParameters().put( 'refId' ,  ap.Account__c);
-		page = apu.cancel();
+		ActionPlan__c ap = ge.createNewActionPlan( 'cases', 0 );
+		ApexPages.currentPage().getParameters().put( 'refType', 'Case' );
+		ApexPages.currentPage().getParameters().put( 'refId' , ap.Case__c + ',' + ge.createNewCase().id);
+		PageReference page = apu.cancel();
 		System.assert( page!= null );
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestCancelContract() {
+		Test.startTest();
+		ActionPlansUtilities apu = new ActionPlansUtilities();
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
+
+		ActionPlan__c ap = ge.createNewActionPlan( 'contracts', 0 );
+		ApexPages.currentPage().getParameters().put( 'refType', 'Contract' );
+		ApexPages.currentPage().getParameters().put( 'refId' , ap.Contract__c + ',' + ge.createNewContract().id);
+		PageReference page = apu.cancel();
+		System.assert( page!= null );
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestCancelTemplate() {
+		Test.startTest();
+		ActionPlansUtilities apu = new ActionPlansUtilities();
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
 		
 		ActionPlanTemplate__c apt = ge.createNewActionPlanTemplate( 0 );
 		ApexPages.currentPage().getParameters().put( 'templateId', apt.Id );
-		page = apu.cancel();
+		PageReference page = apu.cancel();
 		System.assert( page!= null );
 		Test.stopTest();
 	}
 	
-	private static testMethod void APUtestRelatedObjectId() {
-		test.startTest();
-				
+	private static Map<String, ActionPlan__c> APUtestRelatedObjectId(String planType) {
 		ActionPlansTestUtilities ge =  new ActionPlansTestUtilities();
 		
-		ActionPlan__c ap = ge.createNewActionPlan( 'accounts', 0 );
+		ActionPlan__c ap = ge.createNewActionPlan( planType, 0 );
 		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
 		String id = apu.relatedObjectId();
-		System.assert( ap.Account__c == id);
-		
-		ap = ge.createNewActionPlan( 'contacts', 0 );
-		apu = new ActionPlansUtilities(ap);
-		id = apu.relatedObjectId();
-		System.assert( ap.Contact__c == id);
-		
-		ap = ge.createNewActionPlan( 'leads', 0 );
-		apu = new ActionPlansUtilities(ap);
-		id = apu.relatedObjectId();
-		System.assert( ap.Lead__c == id);
-		
-		ap = ge.createNewActionPlan( 'opportunitys', 0 );
-		apu = new ActionPlansUtilities(ap);
-		id = apu.relatedObjectId();
-		System.assert( ap.Opportunity__c == id);
+
+		Map<String, ActionPlan__c> m = new Map<String, ActionPlan__c>();
+		m.put(id, ap);
+		return m;
+	}
+
+	public static testMethod void APUtestRelatedObjectIdAccounts() {
+		test.startTest();
+		Map<String, ActionPlan__c> m = APUtestRelatedObjectId('accounts');
+		for(String id : m.keySet()) {
+			System.assertEquals( m.get(id).Account__c, id);
+		}
+		test.stopTest();
+	}
+
+	public static testMethod void APUtestRelatedObjectIdContacts() {
+		test.startTest();
+		Map<String, ActionPlan__c> m = APUtestRelatedObjectId('contacts');
+		for(String id : m.keySet()) {
+			System.assertEquals( m.get(id).Contact__c, id);
+		}
+		test.stopTest();
+	}
+
+	public static testMethod void APUtestRelatedObjectIdLeads() {
+		test.startTest();
+		Map<String, ActionPlan__c> m = APUtestRelatedObjectId('leads');
+		for(String id : m.keySet()) {
+			System.assertEquals( m.get(id).Lead__c, id);
+		}
+		test.stopTest();
+	}
+
+	public static testMethod void APUtestRelatedObjectIdOpportunitys() {
+		test.startTest();
+		Map<String, ActionPlan__c> m = APUtestRelatedObjectId('opportunitys');
+		for(String id : m.keySet()) {
+			System.assertEquals( m.get(id).Opportunity__c, id);
+		}
+		test.stopTest();
 	}
 	
 	private static testMethod void APUtestHoursOption() {
@@ -301,12 +375,12 @@ public with sharing class ActionPlansUtilitiesTest {
 		test.stopTest();
 	}    
 
-	private static testMethod void APUtestGetRecordOwnerId() {
+	private static testMethod void APUtestGetRecordOwnerIdAccounts() {
 		
 		test.startTest();
 		
 		ActionPlansTestUtilities ge =  new ActionPlansTestUtilities();
-		List<String>oIds = new List<String>();
+		List<String> oIds = new List<String>();
 		
 		ActionPlan__c ap = ge.createNewActionPlan( 'accounts', 0 );
 		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
@@ -315,95 +389,127 @@ public with sharing class ActionPlansUtilitiesTest {
 		apu.retrieveOwnersDataRelatedObject(oIds, 'Account');
 		String owner = apu.getRecordOwnerId(ap);
 		System.assertEquals(a.OwnerId, owner);
+		test.stopTest();
+	}
+
+
+	private static testMethod void APUtestGetRecordOwnerIdCases() {
+
+		test.startTest();
 		
-		ap = ge.createNewActionPlan( 'cases', 0 );
-		apu = new ActionPlansUtilities(ap);
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
+		List<String> oIds = new List<String>();
+
+		ActionPlan__c ap = ge.createNewActionPlan( 'cases', 0 );
+		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
 		Case c = [select Id, OwnerId from Case where id =:ap.Case__c];
-		oIds = new List<String>(); 
 		oIds.add(c.Id);
 		apu.retrieveOwnersDataRelatedObject(oIds, 'Case');
-		owner = apu.getRecordOwnerId(ap);
+		String owner = apu.getRecordOwnerId(ap);
 		System.assertEquals(c.OwnerId, owner);
+		test.stopTest();
+	}
+
+	private static testMethod void APUtestGetRecordOwnerIdContacts() {
 		
-		ap = ge.createNewActionPlan( 'contacts', 0 );
-		apu = new ActionPlansUtilities(ap);
+		test.startTest();
+
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
+		List<String> oIds = new List<String>();
+
+		ActionPlan__c ap = ge.createNewActionPlan( 'contacts', 0 );
+		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
 		Contact contact = [select Id, OwnerId from Contact where id =:ap.Contact__c];
-		oIds = new List<String>(); 
 		oIds.add(contact.Id);
 		apu.retrieveOwnersDataRelatedObject(oIds, 'Contact');
-		owner = apu.getRecordOwnerId(ap);
+		String owner = apu.getRecordOwnerId(ap);
 		System.assertEquals(contact.OwnerId, owner);
+		test.stopTest();
+	}
 		
-		ap = ge.createNewActionPlan( 'contracts', 0 );
-		apu = new ActionPlansUtilities(ap);
+	private static testMethod void APUtestGetRecordOwnerIdContracts() {
+
+		test.startTest();
+
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
+		List<String> oIds = new List<String>();
+
+		ActionPlan__c ap = ge.createNewActionPlan( 'contracts', 0 );
+		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
 		Contract contract = [select Id, OwnerId from Contract where id =:ap.Contract__c];
-		oIds = new List<String>(); 
 		oIds.add(contract.Id);
 		apu.retrieveOwnersDataRelatedObject(oIds, 'Contract');
-		owner = apu.getRecordOwnerId(ap);
+		String owner = apu.getRecordOwnerId(ap);
 		System.assertEquals(contract.OwnerId, owner);
+		test.stopTest();
+	}
+
+	private static testMethod void APUtestGetRecordOwnerIdLeads() {
 		
-		ap = ge.createNewActionPlan( 'leads', 0 );
-		apu = new ActionPlansUtilities(ap);
+		test.startTest();
+
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
+		List<String> oIds = new List<String>();
+
+		ActionPlan__c ap = ge.createNewActionPlan( 'leads', 0 );
+		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
 		Lead l = [select Id, OwnerId from Lead where id =:ap.Lead__c];
-		oIds = new List<String>(); 
 		oIds.add(l.Id);
 		apu.retrieveOwnersDataRelatedObject(oIds, 'Lead');
-		owner = apu.getRecordOwnerId(ap);
+		String owner = apu.getRecordOwnerId(ap);
 		System.assertEquals(l.OwnerId, owner);
+		test.stopTest();
+	}
+
+	private static testMethod void APUtestGetRecordOwnerIdOpportunitys() {
 		
-		ap = ge.createNewActionPlan( 'opportunitys', 0 );
-		apu = new ActionPlansUtilities(ap);
+		test.startTest();
+
+		ActionPlansTestUtilities ge = new ActionPlansTestUtilities();
+		List<String> oIds = new List<String>();
+
+		ActionPlan__c ap = ge.createNewActionPlan( 'opportunitys', 0 );
+		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
 		Opportunity o = [select Id, OwnerId from Opportunity where id =:ap.Opportunity__c];
-		oIds = new List<String>(); 
 		oIds.add(o.Id);
 		apu.retrieveOwnersDataRelatedObject(oIds, 'Opportunity');
-		owner = apu.getRecordOwnerId(ap);
+		String owner = apu.getRecordOwnerId(ap);
 		System.assertEquals(o.OwnerId, owner);
 		
 		test.stopTest();
 	}
-
-	private static testMethod void APUtestGenerateObjectFeed() {
+	private static void APUtestGenerateObjectFeed(String planType) {
 
 		test.startTest();
 				
 		ActionPlansTestUtilities ge =  new ActionPlansTestUtilities();
 
-		ActionPlan__c ap = ge.createNewActionPlan( 'accounts', 0 );
+		ActionPlan__c ap = ge.createNewActionPlan( planType, 0 );
 		ActionPlansUtilities apu = new ActionPlansUtilities(ap);
 		apu.generateObjectFeed(ap.Id);
-		
-		ap = ge.createNewActionPlan( 'campaigns', 0 );
-		apu = new ActionPlansUtilities(ap);
-		apu.generateObjectFeed(ap.Id);
-		
-		
-		ap = ge.createNewActionPlan( 'cases', 0 );
-		apu = new ActionPlansUtilities(ap);
-		apu.generateObjectFeed(ap.Id);
-		
-		
-		ap = ge.createNewActionPlan( 'contacts', 0 );
-		apu = new ActionPlansUtilities(ap);
-		apu.generateObjectFeed(ap.Id);
-		
-		
-		ap = ge.createNewActionPlan( 'contracts', 0 );
-		apu = new ActionPlansUtilities(ap);
-		apu.generateObjectFeed(ap.Id);
-		
-		
-		ap = ge.createNewActionPlan( 'leads', 0 );
-		apu = new ActionPlansUtilities(ap);
-		apu.generateObjectFeed(ap.Id);
-		
-		
-		ap = ge.createNewActionPlan( 'opportunitys', 0 );
-		apu = new ActionPlansUtilities(ap);
-		apu.generateObjectFeed(ap.Id);
-		
-		test.stopTest();
+		Test.stopTest();
+	}
+
+	private static testMethod void APUtestGenerateObjectFeedAccounts() {
+		APUtestGenerateObjectFeed( 'accounts' );
+	}
+	private static testMethod void APUtestGenerateObjectFeedCampaigns() {
+		APUtestGenerateObjectFeed( 'campaigns' );
+	}
+	private static testMethod void APUtestGenerateObjectFeedCases() {
+		APUtestGenerateObjectFeed( 'cases' );
+	}
+	private static testMethod void APUtestGenerateObjectFeedContacts() {
+		APUtestGenerateObjectFeed( 'contacts' );
+	}
+	private static testMethod void APUtestGenerateObjectFeedContracts() {
+		APUtestGenerateObjectFeed( 'contracts' );
+	}
+	private static testMethod void APUtestGenerateObjectFeedLeads() {
+		APUtestGenerateObjectFeed( 'leads' );
+	}
+	private static testMethod void APUtestGenerateObjectFeedOpportunitys() {
+		APUtestGenerateObjectFeed( 'opportunitys' );
 	}
 	
 	public static testMethod void APUtestDeleteActionPlans() {


### PR DESCRIPTION
Many of the tests on ActionPlans unmanaged package were broken. They called too many futures. This was due to either creating more than one user (one at a time) or adding a whole lot of action plans and data in a test case. For the user creation issue, I made it possible to create users at the beginning. For the lots of data issue, I broke up the test cases into one test case per type of item. That all seemed to work and give decent test coverage. I also added an @isTest annotation to one test class that lacked it (thereby lowering our code coverage stats).
